### PR TITLE
fix typo on dotnet-exec builder.py

### DIFF
--- a/Payload_Type/kharon/Mythic/Kharon/AgentFunctions/builder.py
+++ b/Payload_Type/kharon/Mythic/Kharon/AgentFunctions/builder.py
@@ -317,7 +317,7 @@ class KharonAgent(PayloadType):
                 await upload_file(dotnet_file, "Dotnet")
 
             for shellcode_file in shellcode_files:
-                await upload_file(dotnet_file, "Shellcode")
+                await upload_file(shellcode_file, "Shellcode")
 
         except Exception as main_exception:
             logging.error(f"[Modules Upload] Critical error in upload process: {str(main_exception)}")


### PR DESCRIPTION
fix error 
```
[+] Sending Rubeus.exe with 467968 bytes
[+] Hardware Breakpoint bypass disabled
[+] Patch exit Disabled
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/mythic_container/agent_utils.py", line 453, in createTasking
    createTaskingResponse = await cmd.create_go_tasking(taskData)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Mythic/Mythic/Kharon/AgentFunctions/dotnet.py", line 499, in create_go_tasking
    content: bytes = await get_content_by_name("kh_dotnet_assembly.x64.bin", task.Task.ID)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Mythic/Mythic/Kharon/AgentFunctions/Utils/u.py", line 661, in get_content_by_name
    AgentFileId=file_resp.Files[0].AgentFileId
                ~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

module `kh_dotnet_assembly.x64.bin` not loading correctly