### PR TITLE
Fixed typo in socks.py

### DIFF
--- a/Payload_Type/kharon/Mythic/Kharon/AgentFunctions/socks.py
+++ b/Payload_Type/kharon/Mythic/Kharon/AgentFunctions/socks.py
@@ -99,7 +99,7 @@ class SocksCommand(CommandBase):
                 response.TaskStatus = MythicStatus.Error
                 response.Stderr = resp.Error
                 await SendMythicRPCResponseCreate(MythicRPCResponseCreateMessage(
-                    TaskID=taskData.task.ID,
+                    TaskID=taskData.Task.ID,
                     Response=resp.Error.encode()
                 ))
             else:


### PR DESCRIPTION
Fix for the following error, when using socks in the agent:
`Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/mythic_container/agent_utils.py", line 453, in createTasking
    createTaskingResponse = await cmd.create_go_tasking(taskData)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Mythic/Mythic/Kharon/AgentFunctions/socks.py", line 102, in create_go_tasking
    TaskID=taskData.task.ID,
           ^^^^^^^^^^^^^
AttributeError: 'PTTaskMessageAllData' object has no attribute 'task'. Did you mean: 'Task'?`